### PR TITLE
Display save times in locale instead of ISO UTC

### DIFF
--- a/ui/App/views/Saves/Saves.jsx
+++ b/ui/App/views/Saves/Saves.jsx
@@ -71,7 +71,7 @@ const Saves = ({serverStatus}) => {
                             {saves.map(save =>
                                 <tr className="py-2 md:py-1" key={save.name}>
                                     <td className="pr-4">{save.name}</td>
-                                    <td className="pr-4">{(new Date(save.last_mod)).toISOString().replace('T', ' ').split('.')[0]}</td>
+                                    <td className="pr-4">{(new Date(save.last_mod)).toLocaleString()}</td>
                                     <td className="pr-4">{parseFloat(save.size / 1024 / 1024).toFixed(3)} MB</td>
                                     <td>
                                         { save.name !== 'Load Latest' && <>


### PR DESCRIPTION
This changes the save times of save games in the user's locale format and timezone rather than in ISO format with UTC timezone.